### PR TITLE
Emoji chars support

### DIFF
--- a/src/Keboola/DbWriter/Writer/MySQL.php
+++ b/src/Keboola/DbWriter/Writer/MySQL.php
@@ -39,6 +39,7 @@ class MySQL extends Writer implements WriterInterface
 	protected $db;
 
 	private $batched = true;
+	private $charset = 'utf8mb4';
 
 	public function generateTmpName($tableName)
 	{
@@ -99,7 +100,7 @@ class MySQL extends Writer implements WriterInterface
 		$port = isset($dbParams['port']) ? $dbParams['port'] : '3306';
 
 		$dsn = sprintf(
-			"mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4",
+			"mysql:host=%s;port=%s;dbname=%s;charset=$this->charset",
 			$dbParams['host'],
 			$port,
 			$dbParams['database']
@@ -109,7 +110,7 @@ class MySQL extends Writer implements WriterInterface
 
 		$pdo = new \PDO($dsn, $dbParams['user'], $dbParams['password'], $options);
 		$pdo->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
-		$pdo->exec("SET NAMES utf8mb4;");
+		$pdo->exec("SET NAMES $this->charset;");
 
 		if ($isSsl) {
 			$status = $pdo->query("SHOW STATUS LIKE 'Ssl_cipher';")->fetch(\PDO::FETCH_ASSOC);
@@ -132,7 +133,7 @@ class MySQL extends Writer implements WriterInterface
 		$query = "
             LOAD DATA LOCAL INFILE '{$csv}'
             INTO TABLE {$this->escape($table['dbName'])}
-            CHARACTER SET utf8mb4
+            CHARACTER SET $this->charset
             FIELDS TERMINATED BY ','
             OPTIONALLY ENCLOSED BY '\"'
             ESCAPED BY ''
@@ -227,7 +228,7 @@ class MySQL extends Writer implements WriterInterface
 
 
 		$sql = substr($sql, 0, -1);
-		$sql .= ") DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci";
+		$sql .= ") DEFAULT CHARSET=$this->charset COLLATE {$this->charset}_unicode_ci";
 
 		$this->db->exec($sql);
 	}

--- a/src/Keboola/DbWriter/Writer/MySQL.php
+++ b/src/Keboola/DbWriter/Writer/MySQL.php
@@ -100,7 +100,7 @@ class MySQL extends Writer implements WriterInterface
 		$port = isset($dbParams['port']) ? $dbParams['port'] : '3306';
 
 		$dsn = sprintf(
-			"mysql:host=%s;port=%s;dbname=%s;charset=$this->charset",
+			"mysql:host=%s;port=%s;dbname=%s",
 			$dbParams['host'],
 			$port,
 			$dbParams['database']
@@ -110,7 +110,12 @@ class MySQL extends Writer implements WriterInterface
 
 		$pdo = new \PDO($dsn, $dbParams['user'], $dbParams['password'], $options);
 		$pdo->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
-		$pdo->exec("SET NAMES $this->charset;");
+		try {
+			$pdo->exec("SET NAMES $this->charset;");
+		} catch (\PDOException $e) {
+			$this->charset = 'utf8';
+			$pdo->exec("SET NAMES $this->charset;");
+		}
 
 		if ($isSsl) {
 			$status = $pdo->query("SHOW STATUS LIKE 'Ssl_cipher';")->fetch(\PDO::FETCH_ASSOC);

--- a/src/Keboola/DbWriter/Writer/MySQL.php
+++ b/src/Keboola/DbWriter/Writer/MySQL.php
@@ -99,7 +99,7 @@ class MySQL extends Writer implements WriterInterface
 		$port = isset($dbParams['port']) ? $dbParams['port'] : '3306';
 
 		$dsn = sprintf(
-			"mysql:host=%s;port=%s;dbname=%s;charset=utf8",
+			"mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4",
 			$dbParams['host'],
 			$port,
 			$dbParams['database']
@@ -109,7 +109,7 @@ class MySQL extends Writer implements WriterInterface
 
 		$pdo = new \PDO($dsn, $dbParams['user'], $dbParams['password'], $options);
 		$pdo->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
-		$pdo->exec("SET NAMES utf8;");
+		$pdo->exec("SET NAMES utf8mb4;");
 
 		if ($isSsl) {
 			$status = $pdo->query("SHOW STATUS LIKE 'Ssl_cipher';")->fetch(\PDO::FETCH_ASSOC);
@@ -132,7 +132,7 @@ class MySQL extends Writer implements WriterInterface
 		$query = "
             LOAD DATA LOCAL INFILE '{$csv}'
             INTO TABLE {$this->escape($table['dbName'])}
-            CHARACTER SET utf8
+            CHARACTER SET utf8mb4
             FIELDS TERMINATED BY ','
             OPTIONALLY ENCLOSED BY '\"'
             ESCAPED BY ''
@@ -227,7 +227,7 @@ class MySQL extends Writer implements WriterInterface
 
 
 		$sql = substr($sql, 0, -1);
-		$sql .= ") DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
+		$sql .= ") DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci";
 
 		$this->db->exec($sql);
 	}

--- a/src/Keboola/DbWriter/Writer/MySQL.php
+++ b/src/Keboola/DbWriter/Writer/MySQL.php
@@ -114,6 +114,7 @@ class MySQL extends Writer implements WriterInterface
 			$pdo->exec("SET NAMES $this->charset;");
 		} catch (\PDOException $e) {
 			$this->charset = 'utf8';
+			echo 'Falling back to ' . $this->charset . ' charset' . "\n";
 			$pdo->exec("SET NAMES $this->charset;");
 		}
 

--- a/tests/data/mysql/special.csv
+++ b/tests/data/mysql/special.csv
@@ -2,7 +2,7 @@
 "line with enclosure","second column"
 "column with enclosure "", and comma inside text","second column enclosure in text """
 "columns with
-new line","columns with         tab"
+new line","columns with 	tab"
 "column with backslash \ inside","column with backslash and enclosure \"""
 "column with \n \t \\","second col"
 "single quote'","two single''quotes"

--- a/tests/data/mysql/special.csv
+++ b/tests/data/mysql/special.csv
@@ -2,10 +2,11 @@
 "line with enclosure","second column"
 "column with enclosure "", and comma inside text","second column enclosure in text """
 "columns with
-new line","columns with 	tab"
+new line","columns with         tab"
 "column with backslash \ inside","column with backslash and enclosure \"""
 "column with \n \t \\","second col"
 "single quote'","two single''quotes"
 "first","something with
 
 double new line"
+"emoji","Hola hola, škola volá!😜 Nevěš hlavu a ber to jako..."


### PR DESCRIPTION
- use charset utf8mb4 everywhere is possible to support emoji characters
- if setting charset to `utf8mb4` fails then try to use `utf8`