### PR TITLE
MySQL server gone away as user error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/data/out/
 composer.phar
 runtests.sh
 test.php
+.env

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # MySQL DB Writer
 
-[![Docker Repository on Quay](https://quay.io/repository/keboola/db-writer-mysql/status "Docker Repository on Quay")](https://quay.io/repository/keboola/db-writer-mysql)
-[![Build Status](https://travis-ci.com/keboola/db-writer-mysql.svg?branch=master)](https://travis-ci.com/keboola/db-writer-mysql)
-[![Code Climate](https://codeclimate.com/github/keboola/db-writer-mysql/badges/gpa.svg)](https://codeclimate.com/github/keboola/db-writer-mysql)
-[![Test Coverage](https://codeclimate.com/github/keboola/db-writer-mysql/badges/coverage.svg)](https://codeclimate.com/github/keboola/db-writer-mysql/coverage)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/keboola/db-writer-mysql/blob/master/LICENSE.md)
 
 Imports CSV data into MySQL Database.

--- a/src/Writer/MySQL.php
+++ b/src/Writer/MySQL.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbWriter\Writer;
 
+use ErrorException;
 use Iterator;
 use Keboola\Csv\CsvFile;
 use Keboola\DbWriter\Exception\ApplicationException;
@@ -147,7 +148,7 @@ class MySQL extends Writer implements WriterInterface
         try {
             $this->db->exec($query);
             $this->logMysqlWarnings();
-        } catch (PDOException $e) {
+        } catch (PDOException|ErrorException $e) {
             throw new UserException('Query failed: ' . $e->getMessage(), 400, $e, [
                 'query' => $query,
             ]);

--- a/tests/phpunit/Writer/MySQLTest.php
+++ b/tests/phpunit/Writer/MySQLTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Keboola\DbWriter\Tests\Writer;
 


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/CM-288

PDO je sice nakonfigurované aby vracelo PDOException, ale z nějakého důvodu "MySQL server gone away" se vrací jako ErrorException. Povedlo se mi to zreplikovat, sestřelováním MySQL kontejneru (nakonec trochu zbytečně protože v té stack trace v Jira je napsaný, že previousErr bylo ErrorException, jenom jsem to nějak přehlídl 😞). V testu jsem to namockoval podle té stack trace, nepřišel jsem na žádný způsob jak tu chybu nasimulovat v testu jinak (zkoušel jsem nastavit malý packet size a pak ho překročit, ale asi už to v nových verzích nefunguje - vracelo to jinou chybu než MySQL server gone away). Proč to PDO nevrací PDOException ale PHP error netuším. Stejná chyba, jsem dohledal, se kdysi dávno řešila v extractoru (https://github.com/keboola/db-extractor-mysql/issues/46), ale byla spojená s další chybným chováním a řešilo se retryem. Tady imho není potřeba, asi to není časté issue.