### PR TITLE
Turn off column types validation

### DIFF
--- a/src/Writer/MySQLWriteAdapter.php
+++ b/src/Writer/MySQLWriteAdapter.php
@@ -69,6 +69,11 @@ class MySQLWriteAdapter extends PdoWriteAdapter
         }
     }
 
+    public function validateTable(string $tableName, array $items): void
+    {
+        // Don't validate table column types for MySQL - for BC reasons
+    }
+
     public function drop(string $tableName): void
     {
         if (!$this->tableExists($tableName)) {


### PR DESCRIPTION
v původní verzi tahle validace ve writeru nebyla tak jí vypnu i tady, job pak skončí na chybě

Keboola\DockerBundle\Exception\UserException:  Column 'metricsAverageCpc' is of type 'NUMERIC' in writer, but is 'decimal' in destination table 'report-gads_campaigns_insights'

u některých writerů to je taky vypnutý [pgsql](https://github.com/keboola/db-writer-pgsql/blob/master/src/Writer/PgsqlWriteAdapter.php#L169)/[snowflake](https://github.com/keboola/db-writer-snowflake/blob/master/src/Writer/SnowflakeWriteAdapter.php#L99)